### PR TITLE
Implement cleared cells, fix part 2, brainstorm alternative improved agents

### DIFF
--- a/Agent.py
+++ b/Agent.py
@@ -163,8 +163,9 @@ def moveAnyAgent(board: Board):
         if target_nearby and searches > 1:
             cell = board.bestLocal(cell,5)
         else: #Should probably have a better algorithm for this
-            cell = board.bestContains()
+            cell = board.bestContainsMoving()
         found_target, target_nearby = board.exploreMove(cell) #explore current cell
+        board.target_movement() #Target walks
         if found_target: #found target, stop
             break
         #otherwise, update probability of searched cell
@@ -180,19 +181,18 @@ def moveCloseAgent(board: Board):
     while True: #continue until target is found
         actions += 1 #take 1 action per turn
         found_target, target_nearby = board.exploreMove(curcell) #explore current cell
+        board.target_movement() #Target walks
         if found_target: #found target, stop
             break
         #otherwise, update probability of searched cell
         board.update_probability(curcell)
-        if curcell == best_cell: #find new best cell
-            if target_nearby:
-                best_cell = board.bestLocal(curcell,5)
-            else:
-                best_cell = board.bestDistNumpy(curcell)
         if target_nearby:
             best_cell = board.bestLocal(curcell,5)
         else:
-            best_cell = board.bestDistNumpy(curcell)
-        actions += board.manhattan(curcell, best_cell) #Add the actions of moving to the new location
+            best_cell = board.bestDistMoving(curcell)
+        num_walk_actions = board.manhattan(curcell, best_cell)
+        actions += num_walk_actions #Add the actions of moving to the new location
+        for _ in range(num_walk_actions): #Allow the target to walk for each action we take
+            board.target_movement()
         curcell = best_cell
     return actions

--- a/Agent.py
+++ b/Agent.py
@@ -118,6 +118,42 @@ def improvedAgent(board: Board):
         curcell = best_cell
     return actions
 
+def improvedAgent2(board: Board):
+    '''A modified version of agent 3 that utilizes a weighted distance heuristic'''
+    actions = 0
+    best_cell = (-1,-1)
+    curcell = board.bestFind() #Start on best cell
+    while True: #continue until target is found
+        actions += 1 #Exploring the cell is an action
+        #Explore the cell
+        if board.explore(curcell) == FOUND:
+            break
+        #Update probabilities
+        board.update_probability(curcell)
+        #Find the next smallest
+        best_cell = board.bestWeightedDist(curcell)
+        actions += board.manhattan(curcell, best_cell) #Add the actions of moving to the new location
+        curcell = best_cell
+    return actions
+
+def improvedAgent3(board: Board):
+    '''A modified version of agent 3 that utilizes a weighted distance heuristic'''
+    actions = 0
+    best_cell = (-1,-1)
+    curcell = board.bestFind() #Start on best cell
+    while True: #continue until target is found
+        actions += 1 #Exploring the cell is an action
+        #Explore the cell
+        if board.explore(curcell) == FOUND:
+            break
+        #Update probabilities
+        board.update_probability(curcell)
+        #Find the next smallest
+        best_cell = board.bestWeightedDist2(curcell)
+        actions += board.manhattan(curcell, best_cell) #Add the actions of moving to the new location
+        curcell = best_cell
+    return actions
+
 def moveAnyAgent(board: Board):
     '''agent for a board with a moving target. Can move to any space on the board each turn. Use basicAgent1 strategy to search spaces until we get close to the target, then use local search. Return the number of searches.'''
     target_nearby = False

--- a/Board.py
+++ b/Board.py
@@ -13,7 +13,7 @@ MISSING = 0
 
 class Board:
 
-    def __init__(self, dim: int, copy_board=None, copy_target=None):
+    def __init__(self, dim: int, copy_board=None, copy_target=None, moving_target=False):
         self.dim = dim
         if copy_board is None:
             self._board = np.random.choice([FLAT,HILL,FOREST,CAVE], (dim, dim), True, [0.2,0.3,0.3,0.2])
@@ -27,7 +27,8 @@ class Board:
         self._board_mask[self._board == HILL] *= 0.7
         self._board_mask[self._board == FOREST] *= 0.3
         self._board_mask[self._board == CAVE] *= 0.1
-        searched = np.full((dim,dim),0) #count the number of times each cells has been searched
+        if moving_target:
+            self._known_cleared = np.ones((dim, dim))
 
     #Not used
     def newTarget(self):
@@ -61,6 +62,19 @@ class Board:
         else:
             self.board[pos[0]][pos[1]] *= 0.9
         return
+    
+    def target_movement(self) -> None:
+        '''Move the target when there is a new action'''
+        neighbors = self.getNeighbors(self.target)
+        if len(neighbors) > 0:
+            self.target = choice(neighbors)
+        self.update_cleared_cells()
+        return
+    
+    def update_cleared_cells(self) -> None:
+        '''Update the cleared cells matrix upon another action'''
+        self._known_cleared = np.maximum(np.ones((self.dim, self.dim)), self._known_cleared - 1)
+        return
 
     def exploreMove(self, pos: tuple) -> tuple:
         '''explore for moving targets, returns a tuple containing (found/missing target, bool of whether the target is within 5 manhattan distance)'''
@@ -72,15 +86,19 @@ class Board:
             terrain = self._board[pos[0]][pos[1]]
             if terrain == FLAT:
                 ret = np.random.choice([0,1],1,False,[0.1,0.9])
-            if terrain == HILL:
+            elif terrain == HILL:
                 ret = np.random.choice([0,1],1,False,[0.3,0.7])
-            if terrain == FOREST:
+            elif terrain == FOREST:
                 ret = np.random.choice([0,1],1,False,[0.7,0.3])
             else:
                 ret = np.random.choice([0,1],1,False,[0.9,0.1])
         if ret == 0:
-            self.target = choice(self.getNeighbors(self.target)) #move target to random neighbor
             if self.manhattan(pos, self.target) > 5:
+                #Prevent these cells from being visited again soon, poor python implementation - hopefully can find a proper numpy implementation
+                neighborhood = [(row, col) for row in range(max(0, pos[0]-5), min(self.dim, pos[0]+6)) for col in range(max(0, pos[1]-5), min(self.dim, pos[1]+6)) if (abs(row-pos[0]) + abs(col-pos[1])) <= 5]
+                for neighbor in neighborhood:
+                    row, col = neighbor
+                    self._known_cleared[row][col] = 6 - self.manhattan(neighbor, pos) #Number of turns until the target can walk to the position
                 return (False, False)
             return (False, True)
         return (True, True)
@@ -91,11 +109,11 @@ class Board:
         neighbors = []
         if row != 0:
             neighbors.append((row-1, col))
-        if row != self.dim:
+        if row != self.dim-1:
             neighbors.append((row+1, col))
         if col != 0:
             neighbors.append((row, col-1))
-        if col != self.dim:
+        if col != self.dim-1:
             neighbors.append((row, col+1))
         return neighbors
 
@@ -128,6 +146,12 @@ class Board:
         max_pos = self.board.argmax()
         return max_pos//self.dim, max_pos % self.dim
 
+    def bestContainsMoving(self) -> tuple:
+        '''Returns cell with best chance out of cells that are not cleared'''
+        search_board = self.board * (self._known_cleared == 1)
+        max_pos = search_board.argmax()
+        return max_pos//self.dim, max_pos % self.dim
+
     def bestFind(self) -> tuple:
         '''returns cell with best chance of finding the target'''
         temp = np.multiply(self.board, self._board_mask)
@@ -153,6 +177,16 @@ class Board:
         x_target, y_target = pos
         col_diff, row_diff = np.abs(np.mgrid[-x_target:self.dim-x_target, -y_target:self.dim-y_target])
         distance_mask = col_diff + row_diff + 1
+        scores = np.divide(distance_mask, self.board)
+        min_pos = scores.argmin()
+        return min_pos // self.dim, min_pos % self.dim
+    
+    def bestDistMoving(self, pos) -> tuple:
+        '''(Manhattan Distance)/(Probability) heuristic with moving target'''
+        x_target, y_target = pos
+        col_diff, row_diff = np.abs(np.mgrid[-x_target:self.dim-x_target, -y_target:self.dim-y_target])
+        distance_mask = col_diff + row_diff + 1
+        distance_mask = distance_mask * np.where(self._known_cleared == 1, self._known_cleared, 99999) #Prevent those which have been cleared from being chosen
         scores = np.divide(distance_mask, self.board)
         min_pos = scores.argmin()
         return min_pos // self.dim, min_pos % self.dim

--- a/Board.py
+++ b/Board.py
@@ -156,6 +156,26 @@ class Board:
         scores = np.divide(distance_mask, self.board)
         min_pos = scores.argmin()
         return min_pos // self.dim, min_pos % self.dim
+    
+    def bestWeightedDist(self, pos) -> tuple:
+        '''Utilizes a similar manhattan dist/probability heuristic, but weighted'''
+        x_target, y_target = pos
+        col_diff, row_diff = np.abs(np.mgrid[-x_target:self.dim-x_target, -y_target:self.dim-y_target])
+        distance_mask = col_diff + row_diff + 1
+        distance_mask = np.maximum(np.ones((self.dim, self.dim)), distance_mask-5)
+        scores = np.divide(distance_mask, self.board)
+        min_pos = scores.argmin()
+        return min_pos // self.dim, min_pos % self.dim
+
+    def bestWeightedDist2(self, pos) -> tuple:
+        '''Utilizes a similar manhattan dist/probability heuristic, but weighted'''
+        x_target, y_target = pos
+        col_diff, row_diff = np.abs(np.mgrid[-x_target:self.dim-x_target, -y_target:self.dim-y_target])
+        distance_mask = (col_diff + row_diff + 1) * 0.5
+        distance_mask = np.maximum(np.ones((self.dim, self.dim)), distance_mask-5)
+        scores = np.divide(distance_mask, self.board)
+        min_pos = scores.argmin()
+        return min_pos // self.dim, min_pos % self.dim
 
     #Not used
     def isvalid(self, pos):


### PR DESCRIPTION
- Wrote up improvedAgent2 and improvedAgent3, which utilize a weighted (dist)/(prob) heuristic (bestWeightedDist(), bestWeightedDist2()), like agent 3. Overall seem pretty similar to agent3 in terms of performance, so not much of an improvement.

Statistics over 250 iterations: 
```
Agent1  Median: 7047.0, Std Dev: 68151.02063799191
Agent2  Median: 17249.5, Std Dev: 41676.441918666715
Agent3  Median: 6733.0, Std Dev: 10916.948016730683
IAgent  Median: 7365.5, Std Dev: 44993.09564811028
IAgent2 Median: 6757.0, Std Dev: 24917.932618899184
IAgent3 Median: 7062.5, Std Dev: 46672.18396432719
```

- Updated target movement in moveCloseAgent() - Previously I had accidentally made it such that the target didn't move when the agent was walking to its next target.
- Updated Board declaration to allow for a _known_cleared field, which is a matrix of 1's normally, and the number of moves until the target can possibly be in the cell, i.e., a cell value of 3 means that there must be at least 3 turns until the target can be walk to the cell. A value of 1 means that the cell can contain the target. Retrospectively, I should probably have implemented this with 0's instead but 1's made it nice for matrix multiplication.
- Implemented target_movement() and update_cleared_cells() to handle the moving of the target and updating _known_cleared, respectively.
- Updated exploreMove() to flag the cells around the explored cell as cleared if the mine is not within 5 cells. This is stored in _known_cleared, but is executed with a poor python loop, which could (probably?) be improved using numpy because it's relatively slow.
- Fix getNeighbors() to find proper neighbors
- Fix an incorrect if/elif/else that caused all cells to be treated as flat or cave in exploreMove()